### PR TITLE
Deep bites now actually progress over time

### DIFF
--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -933,9 +933,9 @@ void player::hardcoded_effects( effect &it )
             } else if( has_effect( effect_weak_antibiotic ) ) {
                 if( calendar::once_every( 2_turns ) ) {
                     it.mod_duration( 1_turns ); //weak antibiotic slows down by half
-                } else {
-                    it.mod_duration( 1_turns );
                 }
+            } else {
+                it.mod_duration( 1_turns );
             }
         }
     } else if( id == effect_infected ) {


### PR DESCRIPTION
#### Summary
<!--
```SUMMARY: Bugfixes "Deep bites now actually progress over time"```
-->

#### Purpose of change
<!--
Deep bite timers are stuck indefinitely unless the player has used antibiotics before. This bug largely removes the danger from infections, which are otherwise an important part of survival and the earlygame experience.
-->

#### Describe the solution
<!--
Simple fix, just had to move a curly bracket.
-->

#### Additional context
<!--
This is my first time contributing and also my first time using git, please let me know if there are any issues.
-->
